### PR TITLE
Make db txs atomic, use Decimals instead of Floats, and replace prints with logs

### DIFF
--- a/api/firo_wallet_api.py
+++ b/api/firo_wallet_api.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+
 class FiroWalletAPI:
 
     def __init__(self, httpprovider):
@@ -10,11 +11,12 @@ class FiroWalletAPI:
     """
         Create new wallet for new bot member
     """
+
     def create_user_wallet(self):
         response = requests.post(
             self.httpprovider,
             data=json.dumps(
-                {"jsonrpc": "1.0", "id": 1, "method": "getnewaddress"}
+                {"jsonrpc": "1.0", "id": 1, "method": "getsparkdefaultaddress"}
             )).json()
         print(response)
         return response['result']
@@ -22,6 +24,7 @@ class FiroWalletAPI:
     """
         Fetch list of txs
     """
+
     def get_txs_list(self):
         response = requests.post(
             self.httpprovider,
@@ -31,6 +34,16 @@ class FiroWalletAPI:
 
         return response
 
+    def listsparkmints(self):
+        response = requests.post(
+            self.httpprovider,
+            data=json.dumps(
+                {"jsonrpc": "1.0", "id": 2, "method": "listsparkmints"}
+            )).json()
+        print(response)
+        return response
+
+    # TODO - REMOVE
     def listlelantusmints(self):
         response = requests.post(
             self.httpprovider,
@@ -43,6 +56,7 @@ class FiroWalletAPI:
     """
         Get wallet status
     """
+
     def get_wallet_status(self):
         try:
             response = requests.post(
@@ -62,6 +76,7 @@ class FiroWalletAPI:
     """
         Get transaction status
     """
+
     def get_tx_status(self, tx_id):
         response = requests.post(
             self.httpprovider,
@@ -69,10 +84,10 @@ class FiroWalletAPI:
                 {
                     "jsonrpc": "1.0",
                     "id": 4,
-                    "method": "tx_status",
+                    "method": "gettransaction",
                     "params":
                         {
-                            "txId": "%s" % tx_id
+                            "txid": "%s" % tx_id
                         }
                 })).json()
 
@@ -81,6 +96,7 @@ class FiroWalletAPI:
 
     """ 
     """
+
     def automintunspent(self):
         response = requests.post(
             self.httpprovider,
@@ -88,43 +104,110 @@ class FiroWalletAPI:
                 {
                     "jsonrpc": "1.0",
                     "id": 4,
-                    "method": "autoMintlelantus",
+                    "method": "automintspark",
                 })).json()
 
         print(response)
         return response
 
+    """
+            Sends privately if to a Spark address, or deshields if to a transparent address.
+        """
 
+    def spendspark(self, address, value, memo=""):
+        response = requests.post(
+            self.httpprovider,
+            data=json.dumps(
+                {
+                    "jsonrpc": "1.0",
+                    "id": 4,
+                    "method": "spendspark",
+                    "params": [
+                        {
+                            address: {"amount": value, "memo": memo, "subtractFee": False}
+                        }
+                    ]
+
+                })).json()
+        return response
+
+    """
+        Anonymizes (mints) transparent balance to a Spark address
+    """
+
+    def mintspark(self, address, value):
+        response = requests.post(
+            self.httpprovider,
+            data=json.dumps(
+                {
+                    "jsonrpc": "1.0",
+                    "id": 4,
+                    "method": "mintspark",
+                    "params": [
+                        {
+                            address: {"amount": value, "memo": "", "subtractFee": False}
+                        }
+                    ]
+
+                })).json()
+        return response
 
     """
         Send Transaction 
     """
-    def joinsplit(self, address, value):
-        response = requests.post(
-            self.httpprovider,
-            data=json.dumps(
-                {
-                    "jsonrpc": "1.0",
-                    "id": 4,
-                    "method": "joinsplit",
-                    "params": [{address: value}]
-                })).json()
 
-        print(response)
-        return response
-
+    # def joinsplit(self, address, value):
+    #     response = requests.post(
+    #         self.httpprovider,
+    #         data=json.dumps(
+    #             {
+    #                 "jsonrpc": "1.0",
+    #                 "id": 4,
+    #                 "method": "joinsplit",
+    #                 "params": [{address: value}]
+    #             })).json()
+    #
+    #     print(response)
+    #     return response
 
     """ 
     """
-    def listlelantusjoinsplits(self):
+
+    def listsparkspends(self):
         response = requests.post(
             self.httpprovider,
             data=json.dumps(
                 {
                     "jsonrpc": "1.0",
                     "id": 4,
-                    "method": "listlelantusjoinsplits",
-                    "params": [100]
+                    "method": "listsparkspends",
+                })).json()
+        print(response)
+        return response
+    # def listlelantusjoinsplits(self):
+    #     response = requests.post(
+    #         self.httpprovider,
+    #         data=json.dumps(
+    #             {
+    #                 "jsonrpc": "1.0",
+    #                 "id": 4,
+    #                 "method": "listlelantusjoinsplits",
+    #                 "params": [100]
+    #             })).json()
+    #     print(response)
+    #     return response
+
+    """
+    """
+
+    def lelantustospark(self):
+        response = requests.post(
+            self.httpprovider,
+            data=json.dumps(
+                {
+                    "jsonrpc": "1.0",
+                    "id": 4,
+                    "method": "lelantustospark",
                 })).json()
         print(response)
         return response
@@ -132,6 +215,7 @@ class FiroWalletAPI:
     """
         Validate address
     """
+
     def validate_address(self, address):
         response = requests.post(
             self.httpprovider,

--- a/api/firo_wallet_api.py
+++ b/api/firo_wallet_api.py
@@ -20,6 +20,9 @@ class FiroWalletAPI:
             )).json()
         return response['result']
 
+    """
+        Get default spark address for wallet
+    """
     def get_default_address(self):
         response = requests.post(
             self.httpprovider,
@@ -29,6 +32,9 @@ class FiroWalletAPI:
         print(response)
         return response['result']
 
+    """
+        Get txHash Spark address memo, and amount if the transaction is to you 
+    """
     def get_spark_coin_address(self, tx_hash):
         response = requests.post(
             self.httpprovider,
@@ -101,6 +107,7 @@ class FiroWalletAPI:
         return response
 
     """ 
+        Mint Spark
     """
 
     def automintunspent(self):
@@ -117,8 +124,8 @@ class FiroWalletAPI:
         return response
 
     """
-            Sends privately if to a Spark address, or deshields if to a transparent address.
-        """
+        Sends privately if to a Spark address, or deshields if to a transparent address.
+    """
 
     def spendspark(self, address, value, memo=""):
         response = requests.post(

--- a/api/firo_wallet_api.py
+++ b/api/firo_wallet_api.py
@@ -16,7 +16,7 @@ class FiroWalletAPI:
         response = requests.post(
             self.httpprovider,
             data=json.dumps(
-                {"jsonrpc": "1.0", "id": 1, "method": "getsparkdefaultaddress"}
+                {"jsonrpc": "1.0", "id": 1, "method": "getnewsparkaddress"}
             )).json()
         print(response)
         return response['result']

--- a/api/firo_wallet_api.py
+++ b/api/firo_wallet_api.py
@@ -11,13 +11,13 @@ class FiroWalletAPI:
     """
         Create new wallet for new bot member
     """
+
     def create_user_wallet(self):
         response = requests.post(
             self.httpprovider,
             data=json.dumps(
                 {"jsonrpc": "1.0", "id": 1, "method": "getnewsparkaddress"}
             )).json()
-        print(response)
         return response['result']
 
     def get_default_address(self):
@@ -27,6 +27,15 @@ class FiroWalletAPI:
                 {"jsonrpc": "1.0", "id": 1, "method": "getsparkdefaultaddress"}
             )).json()
         print(response)
+        return response['result']
+
+    def get_spark_coin_address(self, tx_hash):
+        response = requests.post(
+            self.httpprovider,
+            data=json.dumps(
+                {"jsonrpc": "1.0", "id": 1, "method": "getsparkcoinaddr", "params":
+                    [tx_hash]}
+            )).json()
         return response['result']
 
     """
@@ -48,7 +57,6 @@ class FiroWalletAPI:
             data=json.dumps(
                 {"jsonrpc": "1.0", "id": 2, "method": "listsparkmints"}
             )).json()
-        print(response)
         return response
 
     """
@@ -168,7 +176,6 @@ class FiroWalletAPI:
                 })).json()
         print(response)
         return response
-
 
     """
     """

--- a/api/firo_wallet_api.py
+++ b/api/firo_wallet_api.py
@@ -43,16 +43,6 @@ class FiroWalletAPI:
         print(response)
         return response
 
-    # TODO - REMOVE
-    def listlelantusmints(self):
-        response = requests.post(
-            self.httpprovider,
-            data=json.dumps(
-                {"jsonrpc": "1.0", "id": 2, "method": "listlelantusmints"}
-            )).json()
-
-        return response
-
     """
         Get wallet status
     """
@@ -124,7 +114,7 @@ class FiroWalletAPI:
                     "method": "spendspark",
                     "params": [
                         {
-                            address: {"amount": value, "memo": memo, "subtractFee": False}
+                            address: {"amount": value, "memo": memo, "subtractFee": True}
                         }
                     ]
 
@@ -156,20 +146,6 @@ class FiroWalletAPI:
         Send Transaction 
     """
 
-    # def joinsplit(self, address, value):
-    #     response = requests.post(
-    #         self.httpprovider,
-    #         data=json.dumps(
-    #             {
-    #                 "jsonrpc": "1.0",
-    #                 "id": 4,
-    #                 "method": "joinsplit",
-    #                 "params": [{address: value}]
-    #             })).json()
-    #
-    #     print(response)
-    #     return response
-
     """ 
     """
 
@@ -184,18 +160,7 @@ class FiroWalletAPI:
                 })).json()
         print(response)
         return response
-    # def listlelantusjoinsplits(self):
-    #     response = requests.post(
-    #         self.httpprovider,
-    #         data=json.dumps(
-    #             {
-    #                 "jsonrpc": "1.0",
-    #                 "id": 4,
-    #                 "method": "listlelantusjoinsplits",
-    #                 "params": [100]
-    #             })).json()
-    #     print(response)
-    #     return response
+
 
     """
     """

--- a/api/firo_wallet_api.py
+++ b/api/firo_wallet_api.py
@@ -11,12 +11,20 @@ class FiroWalletAPI:
     """
         Create new wallet for new bot member
     """
-
     def create_user_wallet(self):
         response = requests.post(
             self.httpprovider,
             data=json.dumps(
                 {"jsonrpc": "1.0", "id": 1, "method": "getnewsparkaddress"}
+            )).json()
+        print(response)
+        return response['result']
+
+    def get_default_address(self):
+        response = requests.post(
+            self.httpprovider,
+            data=json.dumps(
+                {"jsonrpc": "1.0", "id": 1, "method": "getsparkdefaultaddress"}
             )).json()
         print(response)
         return response['result']

--- a/tipbot.py
+++ b/tipbot.py
@@ -202,7 +202,6 @@ class TipBot:
         """
             Check each user actions
         """
-
         # ***** Tip bot section begin *****
         if cmd.startswith("/tip") or cmd.startswith("/atip"):
             if not self._is_user_in_db:
@@ -389,14 +388,14 @@ class TipBot:
         # First get unused mints for the wallet, check if mint is confirmed in the tx list
         unused_mints = []
         mints = wallet_api.listsparkmints()
+
         for mnt in mints['result']:
             if not mnt['isUsed']:
                 unused_mints.append(mnt)
-
         response = self.wallet_api.get_txs_list()
 
-        for unused_mnt in unused_mints:
-            for _tx in response['result']:
+        for _tx in response['result']:
+            for unused_mnt in unused_mints:
                 try:
                     if unused_mnt['txid'] == _tx['txid']:
                         """
@@ -409,14 +408,12 @@ class TipBot:
                         _is_tx_exist_deposit = self.col_txs.find_one(
                             {"txId": _tx['txid'], "type": "deposit"}
                         ) is not None
-
                         if _user_receiver is not None and \
                                 not _is_tx_exist_deposit and \
                                 _tx['confirmations'] >= 2 and _tx['category'] == 'receive':
 
                             value_in_coins = float(_tx['amount'])
                             new_balance = _user_receiver['Balance'] + value_in_coins
-
                             _id = str(uuid.uuid4())
                             self.col_txs.insert_one({
                                 '_id': _id,
@@ -532,7 +529,7 @@ class TipBot:
         mints = wallet_api.listsparkmints()
         if len(mints) > 0:
             # Check if User has a Lelantus address
-            valid = wallet_api.validate_address(_user['Address'])['result']
+            valid = wallet_api.validate_address(_user['Address'][0])['result']
             is_valid_firo = 'isvalid'
             # User still has Lelantus address, Update address and balance
             if is_valid_firo in valid:

--- a/tipbot.py
+++ b/tipbot.py
@@ -1,7 +1,6 @@
 """
-    Developed by @vsnation(t.me/vsnation)
-    Email: vsnation.v@gmail.com
-    If you'll need the support use the contacts ^(above)!
+Created by @vsnation(t.me/vsnation) vsnation.v@gmail.com
+Updated for use with Firo by Likho Jiba (likho) and Joshua Babb (sneurlax@gmail.com).
 """
 import json
 import logging
@@ -53,10 +52,10 @@ WELCOME_MESSAGE = """
 
 class TipBot:
     def __init__(self, wallet_api):
-        # INIT
+        # INIT.
         self.bot = Bot(bot_token)
         self.wallet_api = wallet_api
-        # firo Butler Initialization
+        # Firo Butler Initialization.
         client = MongoClient(connectionString)
         db = client.get_default_database()
         self.col_captcha = db['captcha']
@@ -85,7 +84,7 @@ class TipBot:
         while True:
             try:
                 self._is_user_in_db = None
-                # get chat updates
+                # Get chat updates.
                 new_messages = self.wait_new_message()
                 self.processing_messages(new_messages)
             except Exception as exc:
@@ -105,7 +104,7 @@ class TipBot:
                     else self.new_message.callback_query.message
                 self.text, self._is_video = self.get_action(self.new_message)
                 self.message_text = str(self.text).lower()
-                # init user data
+                # Init user data.
                 self.first_name = self.new_message.effective_user.first_name
                 self.username = self.new_message.effective_user.username
                 self.user_id = int(self.new_message.effective_user.id)
@@ -134,7 +133,7 @@ class TipBot:
                 else:
                     args = None
 
-                # Check if user changed his username
+                # Check if user changed his username.
                 self.check_username_on_change()
                 self.action_processing(str(split[0]).lower(), args)
                 # self.check_group_msg()
@@ -154,7 +153,7 @@ class TipBot:
 
     def get_group_username(self):
         """
-            Get group username
+        Get group username
         """
         try:
             return str(self.message.chat.username)
@@ -163,7 +162,7 @@ class TipBot:
 
     def get_user_username(self):
         """
-                Get User username
+        Get User username
         """
         try:
             return str(self.message.from_user.username)
@@ -197,7 +196,7 @@ class TipBot:
 
     def action_processing(self, cmd, args):
         """
-            Check each user actions
+        Check each user actions
         """
         # ***** Tip bot section begin *****
         if cmd.startswith("/tip") or cmd.startswith("/atip"):
@@ -339,7 +338,7 @@ class TipBot:
 
     def check_username_on_change(self):
         """
-            Check username on change in the bot
+        Check username on change in the bot
         """
         _is_username_in_db = self.col_users.find_one(
             {"username": self.username}) is not None \
@@ -383,10 +382,10 @@ class TipBot:
 
     def update_balance(self):
         """
-            Update user's balance using transactions history
+        Update user's balance using transactions history
         """
         print("Handle TXs")
-        # First get unused mints for the wallet, check if mint is confirmed in the tx list
+        # First get unused mints for the wallet, check if mint is confirmed in the tx list.
         unused_mints = []
         mints = wallet_api.listsparkmints()
 
@@ -507,7 +506,7 @@ class TipBot:
 
     def get_user_data(self):
         """
-            Get user data
+        Get user data
         """
         try:
             _user = self.col_users.find_one({"_id": self.user_id})
@@ -521,10 +520,10 @@ class TipBot:
     def update_address_and_balance(self, _user):
         mints = wallet_api.listsparkmints()
         if len(mints) > 0:
-            # Check if User has a Lelantus address
+            # Check if User has a Lelantus address.
             valid = wallet_api.validate_address(_user['Address'][0])['result']
             is_valid_firo = 'isvalid'
-            # User still has Lelantus address, Update address and balance
+            # User still has Lelantus address, Update address and balance.
             if is_valid_firo in valid:
                 spark_address = wallet_api.create_user_wallet()
                 self.col_users.update_one(
@@ -552,7 +551,7 @@ class TipBot:
                 self.send_message(self.user_id, "<b>You specified an incorrect address</b>", parse_mode='HTML')
                 return
 
-            # Atomic operation to lock the user's balance and update it
+            # Atomic operation to lock the user's balance and update it.
             with client.start_session() as session:
                 with session.start_transaction():
                     user = self.col_users.find_one_and_update(
@@ -565,10 +564,10 @@ class TipBot:
                         self.insufficient_balance_image()
                         return
 
-                    # Proceed with the withdrawal
+                    # Proceed with the withdrawal.
                     response = self.wallet_api.spendspark(address, amount, comment)
                     if response.get('error'):
-                        # Rollback if spend failed
+                        # Rollback if spend failed.
                         self.col_users.update_one(
                             {"_id": self.user_id},
                             {"$inc": {"Balance": amount, "Locked": -(amount + AV_FEE)}},
@@ -578,7 +577,7 @@ class TipBot:
                         self.send_to_logs(f"Unavailable Withdraw\n{str(response)}")
                         return
 
-                    # Insert the transaction into the senders collection
+                    # Insert the transaction into the senders collection.
                     self.col_senders.insert_one(
                         {"txId": response['result'], "status": "pending", "user_id": self.user_id},
                         session=session
@@ -591,9 +590,9 @@ class TipBot:
 
     def tip_user(self, username, amount, comment, _type=None):
         """
-            Tip user with params:
-            username
-            amount
+        Tip user with params:
+        username
+        amount
         """
         try:
             try:
@@ -625,7 +624,7 @@ class TipBot:
 
     def tip_in_the_chat(self, amount, comment="", _type=None):
         """
-            Send a tip to user in the chat
+        Send a tip to user in the chat
         """
         try:
             try:
@@ -651,10 +650,9 @@ class TipBot:
 
     def send_tip(self, user_id, amount, _type, comment):
         """
-            Send tip to user with params
-            user_id - user identificator
-            addrees - user address
-            amount - amount of a tip
+        Send tip to user with params
+        user_id - user identifier
+        amount - amount of a tip
         """
         try:
             if self.user_id == user_id:
@@ -679,14 +677,14 @@ class TipBot:
                         self.insufficient_balance_image()
                         return
 
-                    # Update receiver's balance
+                    # Update receiver's balance.
                     self.col_users.update_one(
                         {"_id": user_id},
                         {"$inc": {"Balance": amount}},
                         session=session
                     )
 
-                    # Log the tip
+                    # Log the tip.
                     tip_log = {
                         "type": "atip" if _type == "anonymous" else "tip",
                         "from_user_id": self.user_id,
@@ -695,7 +693,7 @@ class TipBot:
                     }
                     self.col_tip_logs.insert_one(tip_log, session=session)
 
-                    # Create images
+                    # Create images.
                     self.create_send_tips_image(self.user_id, "{0:.8f}".format(amount), _user_receiver['first_name'], comment)
                     self.create_receive_tips_image(user_id, "{0:.8f}".format(amount), str(_type).title() if _type else self.first_name, comment)
 

--- a/tipbot.py
+++ b/tipbot.py
@@ -375,7 +375,7 @@ class TipBot:
 
     def get_wallet_balance(self):
         try:
-            r = self.wallet_api.listlelantusmints()
+            r = self.wallet_api.listsparkmints()
             result = sum([_x['amount'] for _x in r['result'] if not _x['isUsed']])
             print("Current Balance", result / 1e8)
         except Exception as exc:
@@ -386,166 +386,135 @@ class TipBot:
             Update user's balance using transactions history
         """
         print("Handle TXs")
+
+        # First get unused mints for the wallet, check if mint is confirmed in the tx list
+        unused_mints = []
+        mints = wallet_api.listsparkmints()
+        for mnt in mints['result']:
+            if not mnt['isUsed']:
+                unused_mints.append(mnt)
+
         response = self.wallet_api.get_txs_list()
 
-        for _tx in response['result']:
-            try:
-
-                if not _tx.get('address'):
-                    continue
-
-
-                """
-                    Check withdraw txs    
-                """
-                _user_receiver = self.col_users.find_one(
-                    {"Address": _tx['address']}
-                )
-                _is_tx_exist_deposit = self.col_txs.find_one(
-                    {"txId": _tx['txid'], "type": "deposit"}
-                ) is not None
-
-                if _user_receiver is not None and \
-                        not _is_tx_exist_deposit and \
-                        _tx['confirmations'] >= 2 and _tx['category'] == 'receive':
-
-                    value_in_coins = float(_tx['amount'])
-                    new_balance = _user_receiver['Balance'] + value_in_coins
-
-                    _id = str(uuid.uuid4())
-                    self.col_txs.insert_one({
-                        '_id': _id,
-                        'txId': _tx['txid'],
-                        **_tx,
-                        'type': "deposit",
-                        'timestamp': datetime.datetime.now()
-                    })
-                    self.col_users.update_one(
-                        _user_receiver,
-                        {
-                            "$set":
-                                {
-                                    "Balance": float("{0:.8f}".format(float(new_balance)))
-                                }
-                        }
-                    )
-                    self.create_receive_tips_image(
-                        _user_receiver['_id'],
-                        "{0:.8f}".format(value_in_coins),
-                        "Deposit")
-
-                    print("*Deposit Success*\n"
-                          "Balance of address %s has recharged on *%s* firos." % (
-                              _tx['address'], value_in_coins
-                          ))
-                    continue
-
-                _is_tx_exist_withdraw = self.col_txs.find_one(
-                    {"txId": _tx['txid'], "type": "withdraw"}
-                ) is not None
-
-                pending_sender = self.col_senders.find_one(
-                    {"txId": _tx['txid'], "status": "pending"}
-                )
-                if not pending_sender:
-                    continue
-                _user_sender = self.col_users.find_one({"_id": pending_sender['user_id']})
-                if _user_sender is not None and not _is_tx_exist_withdraw and _tx['category'] == "spend":
-
-                    value_in_coins = float((abs(_tx['amount'])))
-
-                    # if _tx['status'] == 4 or _tx['status'] == 2:
-                    #     self.withdraw_failed_image(_user_sender['_id'])
-                    #     try:
-                    #         reason = _tx['failure_reason']
-                    #     except Exception:
-                    #         reason = "cancelled"
-                    #     self.col_txs.insert({
-                    #         "txId": _tx['txid'],
-                    #         'kernel': '000000000000000000',
-                    #         'receiver': _tx['receiver'],
-                    #         'sender': _tx['sender'],
-                    #         'status': _tx['status'],
-                    #         'fee': _tx['fee'],
-                    #         'reason': reason,
-                    #         'comment': _tx['comment'],
-                    #         'value': _tx['value'],
-                    #         'type': "withdraw",
-                    #         'timestamp': datetime.datetime.now()
-                    #     })
-                    #
-                    #     new_locked = float(_user_sender['Locked']) - value_in_coins
-                    #     new_balance = float(_user_sender['Balance']) + value_in_coins
-                    #
-                    #     self.col_users.update_one(
-                    #         {
-                    #             "_id": _user_sender['_id']
-                    #         },
-                    #         {
-                    #             "$set":
-                    #                 {
-                    #                     "IsWithdraw": False,
-                    #                     "Balance": float("{0:.8f}".format(float(new_balance))),
-                    #                     "Locked": float("{0:.8f}".format(float(new_locked)))
-                    #                 }
-                    #         }
-                    #     )
-
-                    if _tx['confirmations'] >= 2:
-                        _id = str(uuid.uuid4())
-                        self.col_txs.insert_one({
-                            '_id': _id,
-                            "txId": _tx['txid'],
-                            **_tx,
-                            'type': "withdraw",
-                            'timestamp': datetime.datetime.now()
-                        })
-                        new_locked = float(_user_sender['Locked']) - value_in_coins
-                        if new_locked >= 0:
-                            self.col_users.update_one(
-                                {
-                                    "_id": _user_sender['_id']
-                                },
-                                {
-                                    "$set":
-                                        {
-                                            "Locked": float("{0:.8f}".format(new_locked)),
-                                            "IsWithdraw": False
-                                        }
-                                }
-                            )
-                        else:
-                            new_balance = float(_user_sender['Balance']) - value_in_coins
-                            self.col_users.update_one(
-                                {
-                                    "_id": _user_sender['_id']
-                                },
-                                {
-                                    "$set":
-                                        {
-                                            "Balance": float("{0:.8f}".format(new_balance)),
-                                            "IsWithdraw": False
-                                        }
-                                }
-                            )
-
-                        self.create_send_tips_image(_user_sender['_id'],
-                                                    "{0:.8f}".format(float(abs(_tx['amount']))),
-                                                    "%s..." % _tx['address'][:8])
-
-                        self.col_senders.update_one(
-                            {"txId": _tx['txid'], "status": "pending", "user_id": _user_sender['_id']},
-                            {"$set": {"status": "completed"}}
+        for unused_mnt in unused_mints:
+            for _tx in response['result']:
+                try:
+                    if unused_mnt['txid'] == _tx['txid']:
+                        """
+                            Check withdraw txs    
+                        """
+                        wallet_address = wallet_api.create_user_wallet()
+                        _user_receiver = self.col_users.find_one(
+                            {"Address": wallet_address[0]}
                         )
-                        print("*Withdrawal Success*\n"
-                              "Balance of address %s has recharged on *%s* firos." % (
-                                  _user_sender['Address'], value_in_coins
-                              ))
-                        continue
+                        _is_tx_exist_deposit = self.col_txs.find_one(
+                            {"txId": _tx['txid'], "type": "deposit"}
+                        ) is not None
 
-            except Exception as exc:
-                print(exc)
-                traceback.print_exc()
+                        if _user_receiver is not None and \
+                                not _is_tx_exist_deposit and \
+                                _tx['confirmations'] >= 2 and _tx['category'] == 'receive':
+
+                            value_in_coins = float(_tx['amount'])
+                            new_balance = _user_receiver['Balance'] + value_in_coins
+
+                            _id = str(uuid.uuid4())
+                            self.col_txs.insert_one({
+                                '_id': _id,
+                                'txId': _tx['txid'],
+                                **_tx,
+                                'type': "deposit",
+                                'timestamp': datetime.datetime.now()
+                            })
+                            self.col_users.update_one(
+                                _user_receiver,
+                                {
+                                    "$set":
+                                        {
+                                            "Balance": float("{0:.8f}".format(float(new_balance)))
+                                        }
+                                }
+                            )
+                            self.create_receive_tips_image(
+                                _user_receiver['_id'],
+                                "{0:.8f}".format(value_in_coins),
+                                "Deposit")
+
+                            print("*Deposit Success*\n"
+                                  "Balance of address %s has recharged on *%s* firos." % (
+                                      wallet_address[0], value_in_coins
+                                  ))
+                            continue
+
+                        _is_tx_exist_withdraw = self.col_txs.find_one(
+                            {"txId": _tx['txid'], "type": "withdraw"}
+                        ) is not None
+
+                        pending_sender = self.col_senders.find_one(
+                            {"txId": _tx['txid'], "status": "pending"}
+                        )
+                        if not pending_sender:
+                            continue
+                        _user_sender = self.col_users.find_one({"_id": pending_sender['user_id']})
+                        if _user_sender is not None and not _is_tx_exist_withdraw and _tx['category'] == "spend":
+
+                            value_in_coins = float((abs(_tx['amount'])))
+
+                            if _tx['confirmations'] >= 2:
+                                _id = str(uuid.uuid4())
+                                self.col_txs.insert_one({
+                                    '_id': _id,
+                                    "txId": _tx['txid'],
+                                    **_tx,
+                                    'type': "withdraw",
+                                    'timestamp': datetime.datetime.now()
+                                })
+                                new_locked = float(_user_sender['Locked']) - value_in_coins
+                                if new_locked >= 0:
+                                    self.col_users.update_one(
+                                        {
+                                            "_id": _user_sender['_id']
+                                        },
+                                        {
+                                            "$set":
+                                                {
+                                                    "Locked": float("{0:.8f}".format(new_locked)),
+                                                    "IsWithdraw": False
+                                                }
+                                        }
+                                    )
+                                else:
+                                    new_balance = float(_user_sender['Balance']) - value_in_coins
+                                    self.col_users.update_one(
+                                        {
+                                            "_id": _user_sender['_id']
+                                        },
+                                        {
+                                            "$set":
+                                                {
+                                                    "Balance": float("{0:.8f}".format(new_balance)),
+                                                    "IsWithdraw": False
+                                                }
+                                        }
+                                    )
+
+                                self.create_send_tips_image(_user_sender['_id'],
+                                                            "{0:.8f}".format(float(abs(_tx['amount']))),
+                                                            "%s..." % wallet_address[0][:8])
+
+                                self.col_senders.update_one(
+                                    {"txId": _tx['txid'], "status": "pending", "user_id": _user_sender['_id']},
+                                    {"$set": {"status": "completed"}}
+                                )
+                                print("*Withdrawal Success*\n"
+                                      "Balance of address %s has recharged on *%s* firos." % (
+                                          _user_sender['Address'], value_in_coins
+                                      ))
+                                continue
+
+                except Exception as exc:
+                    print(exc)
+                    traceback.print_exc()
 
     def get_user_data(self):
         """
@@ -553,6 +522,7 @@ class TipBot:
         """
         try:
             _user = self.col_users.find_one({"_id": self.user_id})
+            print(f'USER IS {_user}')
             return _user['Address'], _user['Balance'], _user['Locked'], _user['IsWithdraw']
         except Exception as exc:
             print(exc)
@@ -577,7 +547,13 @@ class TipBot:
                 traceback.print_exc()
                 return
 
-            _is_address_valid = self.wallet_api.validate_address(address)['result']['isvalid']
+            _is_address_valid = False
+            validate = self.wallet_api.validate_address(address)['result']
+            is_valid_spark = 'isvalidSpark'
+            is_valid_firo = 'isvalid'
+            if is_valid_spark in validate or is_valid_firo in validate:
+                _is_address_valid = True
+
             if not _is_address_valid:
                 self.send_message(
                     self.user_id,
@@ -592,9 +568,10 @@ class TipBot:
 
                 new_balance = float("{0:.8f}".format(float(self.balance_in_firo - amount)))
                 new_locked = float("{0:.8f}".format(float(self.locked_in_firo + amount - AV_FEE)))
-                response = self.wallet_api.joinsplit(
+                response = self.wallet_api.spendspark(
                     address,
-                    float(amount - AV_FEE),  # fee
+                    float(amount),
+                    comment
                 )
                 print(response, "withdraw")
                 if response.get('error'):

--- a/tipbot.py
+++ b/tipbot.py
@@ -15,7 +15,6 @@ from PIL import Image, ImageFont, ImageDraw
 import matplotlib.pyplot as plt
 import datetime
 import time
-import requests
 from pymongo import MongoClient
 from telegram import Bot, InlineKeyboardMarkup, InlineKeyboardButton
 import uuid
@@ -73,7 +72,7 @@ class TipBot:
             self.first_name, self.username, self.user_id, self.firo_address, \
             self.balance_in_firo, self.locked_in_firo, self.is_withdraw, self.balance_in_groth, \
             self._is_verified, self.group_id, self.group_username = \
-                None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
+            None, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
         self.wallet_api.automintunspent()
         schedule.every(60).seconds.do(self.update_balance)
@@ -152,7 +151,6 @@ class TipBot:
         except Exception as exc:
             print(exc)
 
-
     def get_group_username(self):
         """
             Get group username
@@ -161,7 +159,6 @@ class TipBot:
             return str(self.message.chat.username)
         except Exception:
             return str(self.message.chat.id)
-
 
     def get_user_username(self):
         """
@@ -197,7 +194,6 @@ class TipBot:
 
         return str(menu_option), _is_document
 
-
     def action_processing(self, cmd, args):
         """
             Check each user actions
@@ -205,7 +201,9 @@ class TipBot:
         # ***** Tip bot section begin *****
         if cmd.startswith("/tip") or cmd.startswith("/atip"):
             if not self._is_user_in_db:
-                self.send_message(self.group_id, f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1"><a href="https://t.me/firo_tipbot?start=1">start the bot</a></a>to receive tips!', parse_mode='HTML')
+                self.send_message(self.group_id,
+                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1"><a href="https://t.me/firo_tipbot?start=1">start the bot</a></a>to receive tips!',
+                                  parse_mode='HTML')
                 return
             try:
                 if args is not None and len(args) >= 1:
@@ -244,7 +242,7 @@ class TipBot:
                 self.bot.delete_message(self.group_id, self.message.message_id)
             except Exception:
                 pass
-            
+
             if self.message.chat['type'] == 'private':
                 self.send_message(
                     self.user_id,
@@ -255,7 +253,8 @@ class TipBot:
 
             if not self._is_user_in_db:
                 self.send_message(self.group_id,
-                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!', parse_mode="HTML", disable_web_page_preview=True)
+                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!',
+                                  parse_mode="HTML", disable_web_page_preview=True)
                 return
 
             try:
@@ -271,7 +270,8 @@ class TipBot:
         elif cmd.startswith("catch_envelope|"):
             if not self._is_user_in_db:
                 self.send_message(self.group_id,
-                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!', parse_mode="HTML", disable_web_page_preview=True)
+                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!',
+                                  parse_mode="HTML", disable_web_page_preview=True)
                 return
 
             try:
@@ -286,7 +286,8 @@ class TipBot:
         elif cmd.startswith("/balance"):
             if not self._is_user_in_db:
                 self.send_message(self.group_id,
-                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!', parse_mode="HTML", disable_web_page_preview=True)
+                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!',
+                                  parse_mode="HTML", disable_web_page_preview=True)
                 return
             self.send_message(
                 self.user_id,
@@ -298,7 +299,8 @@ class TipBot:
             try:
                 if not self._is_user_in_db:
                     self.send_message(self.group_id,
-                                      f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!', parse_mode="HTML", disable_web_page_preview=True)
+                                      f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!',
+                                      parse_mode="HTML", disable_web_page_preview=True)
                     return
                 if args is not None and len(args) == 2:
                     self.withdraw_coins(*args)
@@ -311,11 +313,12 @@ class TipBot:
         elif cmd.startswith("/deposit"):
             if not self._is_user_in_db:
                 self.send_message(self.group_id,
-                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!', parse_mode="HTML", disable_web_page_preview=True)
+                                  f'<a href="tg://user?id={self.user_id}">{self.first_name}</a>, <a href="https://t.me/firo_tipbot?start=1">start the bot</a> to receive tips!',
+                                  parse_mode="HTML", disable_web_page_preview=True)
                 return
             self.send_message(
                 self.user_id,
-                dictionary['deposit'] % self.firo_address,
+                dictionary['deposit'] % self.firo_address[0],
                 parse_mode='HTML'
             )
             self.create_qr_code()
@@ -332,8 +335,6 @@ class TipBot:
         # ***** Verification section begin *****
         elif cmd.startswith("/start"):
             self.auth_user()
-
-
 
     def check_username_on_change(self):
         """
@@ -371,7 +372,6 @@ class TipBot:
                 }
             )
 
-
     def get_wallet_balance(self):
         try:
             r = self.wallet_api.listsparkmints()
@@ -401,10 +401,11 @@ class TipBot:
                         """
                             Check withdraw txs    
                         """
-                        wallet_address = wallet_api.create_user_wallet()
+                        sparkcoin_addr = wallet_api.get_spark_coin_address(unused_mnt['txid'])
                         _user_receiver = self.col_users.find_one(
-                            {"Address": wallet_address[0]}
+                            {"Address": sparkcoin_addr[0]['address']}
                         )
+
                         _is_tx_exist_deposit = self.col_txs.find_one(
                             {"txId": _tx['txid'], "type": "deposit"}
                         ) is not None
@@ -438,7 +439,7 @@ class TipBot:
 
                             print("*Deposit Success*\n"
                                   "Balance of address %s has recharged on *%s* firos." % (
-                                      wallet_address[0], value_in_coins
+                                      sparkcoin_addr[0]['address'], value_in_coins
                                   ))
                             continue
 
@@ -496,7 +497,7 @@ class TipBot:
 
                                 self.create_send_tips_image(_user_sender['_id'],
                                                             "{0:.8f}".format(float(abs(_tx['amount']))),
-                                                            "%s..." % wallet_address[0][:8])
+                                                            "%s..." % _user_sender['Address'][0][:8])
 
                                 self.col_senders.update_one(
                                     {"txId": _tx['txid'], "status": "pending", "user_id": _user_sender['_id']},
@@ -556,8 +557,8 @@ class TipBot:
                 amount = float(amount)
             except Exception as exc:
                 self.send_message(self.user_id,
-                                      dictionary['incorrect_amount'],
-                                      parse_mode='HTML')
+                                  dictionary['incorrect_amount'],
+                                  parse_mode='HTML')
                 print(exc)
                 traceback.print_exc()
                 return
@@ -647,8 +648,8 @@ class TipBot:
 
             if not _is_username_exists:
                 self.send_message(self.user_id,
-                                      dictionary['username_error'],
-                                      parse_mode='HTML')
+                                  dictionary['username_error'],
+                                  parse_mode='HTML')
                 return
 
             self.send_tip(_user['_id'], amount, _type, comment)
@@ -656,7 +657,6 @@ class TipBot:
         except Exception as exc:
             print(exc)
             traceback.print_exc()
-
 
     def tip_in_the_chat(self, amount, comment="", _type=None):
         """
@@ -684,7 +684,6 @@ class TipBot:
             print(exc)
             traceback.print_exc()
 
-
     def send_tip(self, user_id, amount, _type, comment):
         """
             Send tip to user with params
@@ -705,8 +704,8 @@ class TipBot:
 
             if _user_receiver is None or _user_receiver['IsVerified'] is False:
                 self.send_message(self.user_id,
-                                      dictionary['username_error'],
-                                      parse_mode='HTML')
+                                  dictionary['username_error'],
+                                  parse_mode='HTML')
                 return
 
             if _type == 'anonymous':
@@ -788,7 +787,6 @@ class TipBot:
             print(exc)
             traceback.print_exc()
 
-
     def create_receive_tips_image(self, user_id, amount, first_name, comment=""):
         try:
             im = Image.open("images/receive_template.png")
@@ -828,8 +826,8 @@ class TipBot:
                 print(exc)
                 if 'blocked' in str(exc):
                     self.send_message(self.group_id,
-                                          "<a href='tg://user?id=%s'>User</a> <b>needs to unblock the bot in order to check their balance!</b>" % user_id,
-                                          parse_mode='HTML')
+                                      "<a href='tg://user?id=%s'>User</a> <b>needs to unblock the bot in order to check their balance!</b>" % user_id,
+                                      parse_mode='HTML')
                 traceback.print_exc()
             except Exception as exc:
                 print(exc)
@@ -864,8 +862,8 @@ class TipBot:
                 print(exc)
                 if 'blocked' in str(exc):
                     self.send_message(self.group_id,
-                                          "<a href='tg://user?id=%s'>User</a> <b>needs to unblock the bot in order to check their balance!</b>" % user_id,
-                                          parse_mode='HTML')
+                                      "<a href='tg://user?id=%s'>User</a> <b>needs to unblock the bot in order to check their balance!</b>" % user_id,
+                                      parse_mode='HTML')
                 traceback.print_exc()
             except Exception as exc:
                 print(exc)
@@ -1295,10 +1293,9 @@ class TipBot:
             print(exc)
             traceback.print_exc()
 
-
     def create_qr_code(self):
         try:
-            url = pyqrcode.create(self.firo_address)
+            url = pyqrcode.create(self.firo_address[0])
             url.png('qrcode.png', scale=6, module_color="#000000",
                     background="#d8e4ee")
             time.sleep(0.5)

--- a/update_address.py
+++ b/update_address.py
@@ -1,0 +1,50 @@
+from pymongo import MongoClient
+import json
+from api.firo_wallet_api import FiroWalletAPI
+
+with open('services.json') as conf_file:
+    conf = json.load(conf_file)
+    connectionString = conf['mongo']['connectionString']
+    httpprovider = conf['httpprovider']
+
+wallet_api = FiroWalletAPI(httpprovider)
+
+
+class AddressFix:
+    def __init__(self, wallet_api):
+        # INIT
+        self.wallet_api = wallet_api
+        client = MongoClient(connectionString)
+        db = client.get_default_database()
+        self.col_users = db['users']
+        self.update_addresses()
+
+    def update_addresses(self):
+        address = self.wallet_api.get_default_address()
+        users = self.col_users.find({"Address": address[0]})
+        for user in users:
+            new_address = wallet_api.create_user_wallet()
+            # Update address
+            self.col_users.update_one(
+                {
+                    "_id": user.get('_id')
+                },
+                {
+                    "$set":
+                        {
+                            "Address": new_address[0],
+                        }
+                }
+            )
+
+
+def main():
+    try:
+        AddressFix(wallet_api)
+
+    except Exception as e:
+        print(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/update_address.py
+++ b/update_address.py
@@ -32,7 +32,7 @@ class AddressFix:
                 {
                     "$set":
                         {
-                            "Address": new_address[0],
+                            "Address": new_address,
                         }
                 }
             )


### PR DESCRIPTION
By making database transactions atomic we can avoid race conditions related to balance updates.

By using Decimals vs. Floats we can avoid imprecise balance calculations.

By replacing prints with proper logging we can save our errors & info messages for later analysis.